### PR TITLE
set kernel in burst_ID_extractor.ipynb

### DIFF
--- a/burst_ID_extractor.ipynb
+++ b/burst_ID_extractor.ipynb
@@ -139,7 +139,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "name": "conda-env-.local-osl_opera_rtc_s1_jbook_env-py"
+   "display_name": "osl_opera_rtc_s1_jbook_env [conda env:.local-osl_opera_rtc_s1_jbook_env]",
+   "language": "python",
+   "name": "conda-env-.local-osl_opera_rtc_s1_jbook_env-osl_opera_rtc_s1_jbook_env"
   },
   "language_info": {
    "codemirror_mode": {
@@ -151,7 +153,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- burst_ID_extractor notebook was missing 'display_name' property that sets the kernel